### PR TITLE
Commit the transaction

### DIFF
--- a/cycli/neo4j.py
+++ b/cycli/neo4j.py
@@ -26,6 +26,7 @@ class Neo4j:
         try:
             tx.append(query)
             results = tx.process()
+            tx.commit()
         except Exception as e:
             results = e
         except KeyboardInterrupt:


### PR DESCRIPTION
First of all, thanks for this amazing and inspiring tool.

The Cypher transactions are never commited which prevents all `CREATE` and `DELETE` statements to be faked, in fact if you run :

```
> CREATE (n:User {name:'Nicole'}) RETURN n;
   | n
---+-----------------------------
 1 | (n870:User {name:"Nicole"})

>
```

A node id is given in the scope of the transaction, but the graph will never be updated and this results also in many transactions remaining open