### PR TITLE
Support new commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,4 @@ venv
 .mozilla
 .nv
 .ipynb_checkpoints
+*.iml

--- a/README.md
+++ b/README.md
@@ -89,6 +89,34 @@ Type "help" to see a table of keywords / keystrokes and their descriptions.
 
 ![help](screenshots/help.png)
 
+### Show Schema
+
+Type "schema" to see all schema - labels, relationship types, constraints, indexes
+
+#### Show labels
+
+Type "schema-labels" to see only labels
+
+#### Show relationship types
+
+Type "schema-relations" to see only relationship types
+
+#### Show constraints
+
+Type "schema-constraints" to see only constraints
+
+#### Show indexes
+
+Type "schema-indexes" to see only indexes
+
+### Refresh schema cache
+
+Type "refresh" to refresh cycli console cache for the schema. Useful when there is some update in schema, while the console is open
+
+### Run a cypher N times
+
+Type "run-10" (say) followed by cypher to run a cypher N times. Useful when you want to make a huge update, and would prefer updating records in 1000 batch (say) 100 times, rather than updating 1,00,000 records with single run.
+
 ### Exiting
 
 Exit cycli by typing "quit" or "exit" or by pressing CTRL-D on an empty line.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Type "schema-labels" to see only labels
 
 #### Show relationship types
 
-Type "schema-relations" to see only relationship types
+Type "schema-rels" to see only relationship types
 
 #### Show constraints
 

--- a/cycli/buffer.py
+++ b/cycli/buffer.py
@@ -19,6 +19,12 @@ class CypherBuffer(Buffer):
                 text.endswith("\n"),
                 text == "quit",
                 text == "exit",
-                text == "help"
+                text == "help",
+                text == "refresh",
+                text == "schema",
+                text == "schema-constraints",
+                text == "schema-indexes",
+                text == "schema-labels",
+                text == "schema-relations"
             ]
         )

--- a/cycli/buffer.py
+++ b/cycli/buffer.py
@@ -25,6 +25,6 @@ class CypherBuffer(Buffer):
                 text == "schema-constraints",
                 text == "schema-indexes",
                 text == "schema-labels",
-                text == "schema-relations"
+                text == "schema-rels"
             ]
         )

--- a/cycli/main.py
+++ b/cycli/main.py
@@ -120,7 +120,7 @@ class Cycli:
                 document = cli.run()
                 query = document.text
 
-                print(query)
+                m = re.match('run-([0-9]+) (.*)', query)
 
                 if query in ["quit", "exit"]:
                     raise Exception
@@ -143,22 +143,23 @@ class Cycli:
                 elif query == "schema-labels":
                     neo4j.print_labels()
 
-                elif query == "schema-relations":
+                elif query == "schema-rels":
                     neo4j.print_relationship_types()
 
-                elif re.match('run-([0-9]+) (.*)', query):
-                    m = re.match('run-([0-9]+) (.*)', query)
+                elif m:
                     count = int(m.group(1))
                     cypher = m.group(2)
 
                     if count <= 0 or not cypher:
                         raise Exception
 
-                    start = datetime.now()
+                    total_duration = 0
 
                     index = 0
                     while index < count:
                         results, duration = neo4j.cypher(cypher)
+                        total_duration += duration
+
                         print(results)
                         print("{} ms".format(duration))
 
@@ -167,9 +168,7 @@ class Cycli:
 
                         index += 1
 
-                    end = datetime.now()
-                    duration = int(round((end - start).total_seconds() * 1000))
-                    print("Total time taken: {} ms".format(duration))
+                    print("{} ms".format(total_duration))
 
                 else:
                     results, duration = neo4j.cypher(query)
@@ -220,7 +219,7 @@ def help_text():
         ("schema-indexes", "Shows all indexes."),
         ("schema-constraints", "Shows all constraints."),
         ("schema-labels", "Shows all labels."),
-        ("schema-relations", "Shows all relationship types."),
+        ("schema-rels", "Shows all relationship types."),
         ("CTRL-D", "Exit cycli if the input is blank."),
         ("CTRL-C", "Abort and rollback the currently-running query.")
     ])

--- a/cycli/main.py
+++ b/cycli/main.py
@@ -120,7 +120,7 @@ class Cycli:
                 document = cli.run()
                 query = document.text
 
-                m = re.match('run-([0-9]+) (.*)', query)
+                m = re.match('run-([0-9]+) (.*)', query, re.DOTALL)
 
                 if query in ["quit", "exit"]:
                     raise Exception
@@ -161,7 +161,8 @@ class Cycli:
                         total_duration += duration
 
                         print(results)
-                        print("{} ms".format(duration))
+                        print("Run-{} : {} ms".format(index+1, duration))
+                        print()
 
                         if self.logfile:
                             self.write_to_logfile(query, results, duration)

--- a/cycli/neo4j.py
+++ b/cycli/neo4j.py
@@ -98,43 +98,47 @@ class Neo4j:
 
     def print_labels(self):
         results = self.labels()
-        print("Labels")
-        print("======")
-        if not results or len(results) == 0:
-            print("    NONE")
+        title = "Labels"
+        print(title)
+        print("=" * len(title))
+        if not results:
+            print("NONE".rjust(4))
         else:
             for value in results:
-                print("    {}".format(value))
+                print("".rjust(4) + "{}".format(value))
 
     def print_relationship_types(self):
         results = self.relationship_types()
-        print("Relationship Types")
-        print("==================")
-        if not results or len(results) == 0:
-            print("    NONE")
+        title = "Relationship Types"
+        print(title)
+        print("=" * len(title))
+        if not results:
+            print("".rjust(4) + "NONE")
         else:
             for value in results:
-                print("    {}".format(value))
+                print("".rjust(4) + "{}".format(value))
 
     def print_constraints(self):
         results = self.constraints()
-        print("Constraints")
-        print("===========")
-        if not results or len(results) == 0:
-            print("    NONE")
+        title = "Constraints"
+        print(title)
+        print("=" * len(title))
+        if not results:
+            print("".rjust(4) + "NONE")
         else:
             for value in results:
-                print("    :{}({})".format(value['label'], ",".join(value['property_keys'])))
+                print("".rjust(4) + ":{}({})".format(value['label'], ",".join(value['property_keys'])))
 
     def print_indexes(self):
         results = self.indexes()
-        print("Indexes")
-        print("=======")
-        if not results or len(results) == 0:
-            print("    NONE")
+        title = "Indexes"
+        print(title)
+        print("=" * len(title))
+        if not results:
+            print("".rjust(4) + "NONE")
         else:
             for value in results:
-                print("    :{}({})".format(value['label'], ",".join(value['property_keys'])))
+                print("".rjust(4) + ":{}({})".format(value['label'], ",".join(value['property_keys'])))
 
     def print_schema(self):
         self.print_labels()


### PR DESCRIPTION
A) Support new commands --
	1) schema-constraints - shows all constraints.
	2) schema-indexes - shows all indexes.
	3) schema-labels - shows all labels.
	4) schema-relations - shows all relationship types.
	5) schema - shows all labels, relationship types, indexes, constraints.
	6) refresh - refresh all schema caches - labels, relationship types, indexes, constraints cache. Useful when there is some change in schema while cycli console is open.
	7) run-n - run the given cypher n times. Many a times one want to update millions of records, rather than doing in a single cypher - we can run cypher 100 times (say) each run limiting updates to 1000 (say).
B) Print help in the order it is mentioned - used OrderedDict