### PR TITLE
Update click

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-click==4.1
+click==6.7
 prompt-toolkit==1.0.15
 py2neo==3.1.2
 Pygments==2.0.2

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(name='cycli',
       license='MIT',
       packages=['cycli'],
       install_requires=[
-        'click==4.1',
+        'click==6.7',
         'prompt-toolkit==1.0.15',
         'Pygments==2.0.2',
         'py2neo==3.1.2'


### PR DESCRIPTION
Another dull PR - `click==4.1` was causing problems with some other packages. This bumps the `click` version to `==6.7` - no breaking changes [`click` changelog](http://click.pocoo.org/6/changelog/) 